### PR TITLE
Updating repository to perform automated coverage testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,17 @@ sudo: false
 language: python
 python:
   - "2.7"
+env:
+  global:
+    - NIFTY_TRAVIS_CACHE_REPO=https://github.com/nimbis/travis-cache-public.git
 install:
   - pip install -r requirements.txt
+before_script:
+  - git clone https://github.com/nimbis/nifty.git ./.nifty
 script:
+  - source .nifty/nifty-script
+  - verify_coverage_improvement
   - make pep8
   - make test
-  - make coverage
 notifications:
   secure: "V7hifJ0c08djuMmGgguzgwUXDkiTtYnIjmtHywn/wqq59U3hhnb7MzgIMxailf5hbh7eQp1rWEkUaJ1l5UCvbMaRFXYAalB3Yzg6gwGVMj3PpbqLKoDBIFC1wGXpQJD2ftaXAiBQId5F+f1xBL7fDcs5qChSDEJ0bNZujXXkOyg="


### PR DESCRIPTION
These changes utilize `nifty` to perform automated coverage
comparison testing using information regarding the master branch's code
test coverage from the travis-cache repository. Builds will now fail if
total test coverage drops below the current value for the master branch
that is stored in the travis-cache-public repository.
