### PR TITLE
Required and mixin

### DIFF
--- a/x509_auth/migrations/0002_x509usermapping_required.py
+++ b/x509_auth/migrations/0002_x509usermapping_required.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('x509_auth', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='x509usermapping',
+            name='required',
+            field=models.BooleanField(default=False, help_text=b'This user must authenticate via x509.'),
+        ),
+    ]

--- a/x509_auth/mixins.py
+++ b/x509_auth/mixins.py
@@ -1,0 +1,20 @@
+# -- code: utf-8 --
+from __future__ import absolute_import
+
+from .models import X509UserMapping
+
+
+class X509ContextMixin(object):
+    def get_context_data(self, **kwargs):
+        context = super(X509ContextMixin, self).get_context_data(**kwargs)
+        if (('HTTP_X_SSL_USER_DN' in self.request.META) and
+           ('HTTP_X_SSL_AUTHENTICATED' in self.request.META)):
+            # A key is asserted, see if we already have it
+            certs = X509UserMapping.objects.filter(
+                user=self.request.user,
+                cert_dn=self.request.META['HTTP_X_SSL_USER_DN'])
+            if not certs.exists():
+                for k in ['HTTP_X_SSL_USER_DN', 'HTTP_X_SSL_AUTHENTICATED']:
+                    # Put in the context for possible addition
+                    context[k] = self.request.META[k]
+        return context

--- a/x509_auth/mixins.py
+++ b/x509_auth/mixins.py
@@ -5,16 +5,24 @@ from .models import X509UserMapping
 
 
 class X509ContextMixin(object):
-    def get_context_data(self, **kwargs):
-        context = super(X509ContextMixin, self).get_context_data(**kwargs)
-        if (('HTTP_X_SSL_USER_DN' in self.request.META) and
-           ('HTTP_X_SSL_AUTHENTICATED' in self.request.META)):
+
+    def x509_modify_context(self, context, request, user):
+        """
+        Some what of a utility method.  Designed to be called by FBVs.  Does
+        not rely on 'self'.  Modifies context in place.
+        """
+        if (('HTTP_X_SSL_USER_DN' in request.META) and
+           ('HTTP_X_SSL_AUTHENTICATED' in request.META)):
             # A key is asserted, see if we already have it
             certs = X509UserMapping.objects.filter(
-                user=self.request.user,
-                cert_dn=self.request.META['HTTP_X_SSL_USER_DN'])
+                user=user,
+                cert_dn=request.META['HTTP_X_SSL_USER_DN'])
             if not certs.exists():
                 for k in ['HTTP_X_SSL_USER_DN', 'HTTP_X_SSL_AUTHENTICATED']:
                     # Put in the context for possible addition
-                    context[k] = self.request.META[k]
+                    context[k] = request.META[k]
+
+    def get_context_data(self, **kwargs):
+        context = super(X509ContextMixin, self).get_context_data(**kwargs)
+        self.x509_modify_context(context, self.request, self.request.user)
         return context

--- a/x509_auth/models.py
+++ b/x509_auth/models.py
@@ -21,5 +21,9 @@ class X509UserMapping(models.Model):
         blank=False,
         unique=True)
 
+    required = models.BooleanField(
+        help_text="This user must authenticate via x509.",
+        default=False)
+
     def __str__(self):
         return "{0}:{1}".format(self.user.username, self.cert_dn)


### PR DESCRIPTION
Add a 'required' field to the X509UserMapping.  Break out certain SSL context bits to be used in CBV and FBV.